### PR TITLE
fix builds failing with gettext missing error

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,24 +1,19 @@
 #!/usr/bin/env bash
 
-# Need to get appropriate response to g_get_system_data_dirs()
-# See the hardcoded-paths.patch file
-export CFLAGS="-DCONDA_PREFIX=\\\"${PREFIX}\\\""
-
 if [[ ${HOST} =~ .*darwin.* ]]; then
-  # Pick up the Conda version of gettext/libintl:
-  export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
-  export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib"
+  # Need to get appropriate response to g_get_system_data_dirs()
+  # See the hardcoded-paths.patch file
+  export CFLAGS="$CFLAGS -DCONDA_PREFIX=\\\"${PREFIX}\\\""
   LIBICONV=gnu
 elif [[ ${HOST} =~ .*linux.* ]]; then
-  # Pick up the Conda version of gettext/libintl:
-  export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
-  export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
   # So the system (builtin to glibc) iconv gets found and used.
   LIBICONV=maybe
+  export PATH="$PATH:$PREFIX/$HOST/sysroot/usr/bin"
 fi
 
 # A full path to PYTHON causes overly long shebang in gobject/glib-genmarshal
 ./configure --prefix=${PREFIX} \
+            --host=$HOST \
             --with-python=$(basename "${PYTHON}") \
             --with-libiconv=${LIBICONV} \
             --disable-libmount \
@@ -30,5 +25,3 @@ make -j${CPU_COUNT} ${VERBOSE_AT}
 # ERROR: fileutils - exited with status 134 (terminated by signal 6?)
 # make check
 make install
-
-rm -rf $PREFIX/share/gdb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     #
     # https://github.com/Homebrew/legacy-homebrew/blob/21ce7a56cb3fc40fe93d731cc654c69268796772/Library/Formula/glib.rb#L33-L39
     #
-    - hardcoded-paths.patch
+    - hardcoded-paths.patch  # [osx]
 
 build:
   number: 1
@@ -32,6 +32,8 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ cdt('gettext-devel') }}  # [linux]
     - python
     - pkg-config
   host:


### PR DESCRIPTION
add missing cxx compiler, re-enable gdb stuff (depends on conda-build fix at https://github.com/conda/conda-build/pull/2468)