### PR TITLE
Update `Glib` to Version `2.70.1`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ build:
   number: 0
   # Python is only ever needed for the build process, so use this next `skip`
   # statement to avoid redudant builds caused by any cbc.yaml.
-  skip: True  # [py<36]
+  skip: True  # [py!=38]
   skip: True  # [win and vc<14]
   missing_dso_whitelist:          # [osx]
     - /usr/lib/libresolv.9.dylib  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ build:
   number: 0
   # Python is only ever needed for the build process, so use this next `skip`
   # statement to avoid redudant builds caused by any cbc.yaml.
-  skip: True  # [py!=38]
+  skip: True  # [py<36]
   skip: True  # [win and vc<14]
   missing_dso_whitelist:          # [osx]
     - /usr/lib/libresolv.9.dylib  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.69.1" %}
+{% set version = "2.70.1" %}
 {% set major_minor = ".".join(version.split(".")[:2]) %}
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
@@ -9,7 +9,7 @@ package:
 
 source:
   url: http://ftp.gnome.org/pub/GNOME/sources/glib/{{ major_minor }}/glib-{{ version }}.tar.xz
-  sha256: f92f34057a091fc8638d91f10cece842cb8618e9a1090b0ddb19cc15a21bf39c
+  sha256: f9b7bce7f51753a1f43853bbcaca8bf09e15e994268e29cfd7a76f65636263c0
   patches:
     # Related to this patch https://bugzilla.gnome.org/show_bug.cgi?id=673135
     # However, it was rejected by upstream. Homebrew decided to keep their own


### PR DESCRIPTION

`glib` version `2.70.1`

  `glib` version `2.70.1`
1. check the upstream
    https://gitlab.gnome.org/GNOME/glib/-/tree/2.71.0

2. check the pinnings
    https://gitlab.gnome.org/GNOME/glib/-/blob/2.71.0/meson.build
    https://gitlab.gnome.org/GNOME/glib/-/blob/2.71.0/glib-gettextize.in
    https://gitlab.gnome.org/GNOME/glib/-/blob/2.71.0/clang-format-diff.py
    https://gitlab.gnome.org/GNOME/glib/-/blob/2.71.0/check-abis.sh
    https://gitlab.gnome.org/GNOME/glib/-/blob/2.71.0/NEWS.pre-1-3
    https://gitlab.gnome.org/GNOME/glib/-/blob/2.71.0/INSTALL.in

3. check the changelogs
    https://gitlab.gnome.org/GNOME/glib/-/blob/2.71.0/NEWS

4. additional research
    https://github.com/conda-forge/glib-feedstock/issues

    Currently there are two open issues in `conda-forge` however both of the issues seem to have solutions posted in the conversation logs for the open issues. 

5. verify dev_url
    https://git.gnome.org/browse/glib/

6. verify doc_url
    https://developer.gnome.org/glib/unstable/

7. veriy the test section
8. additional tests

In order to test the `glib` package version `2.70.1` the folowing
command was used:
`conda build glib-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that relatively safe to update `glib` to version `2.70.1`
