### PR TITLE
set lower bound for libffi to prevent hotfix to lower it to <3.3

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -12,7 +12,7 @@ mkdir forgebuild
 cd forgebuild
 
 @REM Find libffi with pkg-config
-rem FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
 set PKG_CONFIG_PATH=%LIBRARY_PREFIX_M%/lib/pkgconfig;%LIBRARY_PREFIX_M%/share/pkgconfi
 
 @REM Avoid a Meson issue - https://github.com/mesonbuild/meson/issues/4827

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -12,7 +12,7 @@ mkdir forgebuild
 cd forgebuild
 
 @REM Find libffi with pkg-config
-FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+rem FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
 set PKG_CONFIG_PATH=%LIBRARY_PREFIX_M%/lib/pkgconfig;%LIBRARY_PREFIX_M%/share/pkgconfi
 
 @REM Avoid a Meson issue - https://github.com/mesonbuild/meson/issues/4827

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,9 @@ requirements:
     - m2-patch  # [win]
   host:
     - python
-    - libffi >=3.3
+    - libffi >=3.3  # [not win]
+    # code is incompatible to newer libffi headers
+    - libffi <3,3   # [win]
     - gettext   # [osx]
     - zlib
     - pcre

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     - patches/0005-Increase-some-test-timeouts.patch                  # [win]
 
 build:
-  number: 0
+  number: 1
   # Python is only ever needed for the build process, so use this next `skip`
   # statement to avoid redudant builds caused by any cbc.yaml.
   skip: True  # [py!=38]
@@ -49,13 +49,13 @@ requirements:
     - python
   host:
     - python
-    - libffi
+    - libffi >={{ libffi }}
     - gettext   # [osx]
     - zlib
     - pcre
     - libiconv  # [osx or win]
   run:
-    - libffi
+    - libffi >={{ libffi }}
     - gettext   # [osx]
     - zlib
     - pcre

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,6 @@ build:
     - libffi  # [win]
 requirements:
   build:
-    - {{ posix }}patch
     - meson 0.53.2  # [win]
     - meson         # [not win]
     - ninja

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,8 @@ requirements:
     - {{ compiler('cxx') }}
     - setuptools
     - python
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - libffi >={{ libffi }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,13 +51,13 @@ requirements:
     - m2-patch  # [win]
   host:
     - python
-    - libffi >={{ libffi }}
+    - libffi >=3.3
     - gettext   # [osx]
     - zlib
     - pcre
     - libiconv  # [osx or win]
   run:
-    - libffi >={{ libffi }}
+    - libffi >=3.3
     - gettext   # [osx]
     - zlib
     - pcre

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - python
     - libffi >=3.3  # [not win]
     # code is incompatible to newer libffi headers
-    - libffi <3,3   # [win]
+    - libffi <3.3   # [win]
     - gettext   # [osx]
     - zlib
     - pcre


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
