### PR TITLE
correct pkgconfig file on windows

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,8 @@
+# the conda-build parameters to use
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"
+
+channels: 
+  cbouss: glib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     - patches/0005-Increase-some-test-timeouts.patch                  # [win]
 
 build:
-  number: 1
+  number: 2
   # Python is only ever needed for the build process, so use this next `skip`
   # statement to avoid redudant builds caused by any cbc.yaml.
   skip: True  # [py!=38]


### PR DESCRIPTION
Rebuild is needed because glib 2.69.1 on windows has bad pkgconfig data.

gio-2.0.pc contains this:

Requires: glib-2.0, gobject-2.0
Libs.private: C:/ci_310/glib_1642686432177/_h_env/Library/lib/z.lib -lshlwapi -ldnsapi -liphlpapi -lws2_32 -L${libdir} -lintl

While it should contain this:

Requires: zlib, glib-2.0, gobject-2.0
Libs.private: -lshlwapi -ldnsapi -liphlpapi -lws2_32 -L${libdir} -lintl

See: https://anaconda.atlassian.net/browse/PKG-113