### PR TITLE
glib 2.84.4 rebuild: add gobject-introspection

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,6 @@
 # the conda-build parameters to use for disabling --skip-existing
 build_parameters:
   - "--suppress-variables"
+
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,7 +10,7 @@ echo none /tmp usertemp binary,posix=0 0 0 >>%BUILD_PREFIX%\Library\etc\fstab
 
 set "GIR_PREFIX=%cd%\g-ir-prefix"
 
-call conda create -p %GIR_PREFIX% -y -c conda-forge -c defaults g-ir-build-tools gobject-introspection glib "setuptools<71"
+call conda create -p %GIR_PREFIX% -y -c conda-forge -c defaults "python=%PY_VER%" g-ir-build-tools gobject-introspection glib "setuptools<71"
 if errorlevel 1 exit 1
 
 @REM set "PATH=%PATH%;%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,11 +8,20 @@ mkdir %BUILD_PREFIX%\Library\etc
 echo none / cygdrive binary,user 0 0 >%BUILD_PREFIX%\Library\etc\fstab
 echo none /tmp usertemp binary,posix=0 0 0 >>%BUILD_PREFIX%\Library\etc\fstab
 
+set "GIR_PREFIX=%cd%\g-ir-prefix"
 
+call conda create -p %GIR_PREFIX% -y -c conda-forge -c defaults g-ir-build-tools gobject-introspection glib "setuptools<71"
+if errorlevel 1 exit 1
+
+set "PATH=%PATH%;%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin"
+
+mkdir forgebuild
+cd forgebuild
 
 @REM Find libffi with pkg-config
 FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
-set PKG_CONFIG_PATH=%LIBRARY_PREFIX_M%/lib/pkgconfig;%LIBRARY_PREFIX_M%/share/pkgconfig
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%GIR_PREFIX%"') DO set "GIR_PREFIX_M=%%i"
+set PKG_CONFIG_PATH=%LIBRARY_PREFIX_M%/lib/pkgconfig;%LIBRARY_PREFIX_M%/share/pkgconfig;%GIR_PREFIX_M%/Library/lib/pkgconfig
 
 @REM Avoid a Meson issue - https://github.com/mesonbuild/meson/issues/4827
 set "PYTHONLEGACYWINDOWSSTDIO=1"
@@ -20,9 +29,6 @@ set "PYTHONIOENCODING=UTF-8"
 
 @REM See hardcoded-paths.patch
 set "CPPFLAGS=%CPPFLAGS% -D^"%LIBRARY_PREFIX_M%^""
-
-mkdir forgebuild
-cd forgebuild
 
 meson setup --buildtype=release --prefix="%LIBRARY_PREFIX_M%" --backend=ninja -Dselinux=disabled -Dxattr=false -Dlibmount=disabled -Dintrospection=enabled ..
 if errorlevel 1 (

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,7 +10,10 @@ echo none /tmp usertemp binary,posix=0 0 0 >>%BUILD_PREFIX%\Library\etc\fstab
 
 set "GIR_PREFIX=%cd%\g-ir-prefix"
 
-call conda create -p %GIR_PREFIX% -y -c conda-forge -c defaults "python=%PY_VER%" g-ir-build-tools gobject-introspection glib "setuptools<71"
+@REM call conda create -p %GIR_PREFIX% -y -c conda-forge -c defaults "python=%PY_VER%" g-ir-build-tools gobject-introspection glib "setuptools<71"
+@REM if errorlevel 1 exit 1
+
+call conda create -p %GIR_PREFIX% -y "python=%PY_VER%" gobject-introspection glib "setuptools<71"
 if errorlevel 1 exit 1
 
 set "PYTHONPATH=%GIR_PREFIX%\Lib\site-packages;%PYTHONPATH%"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,7 +13,10 @@ set "GIR_PREFIX=%cd%\g-ir-prefix"
 call conda create -p %GIR_PREFIX% -y -c conda-forge -c defaults g-ir-build-tools gobject-introspection glib "setuptools<71"
 if errorlevel 1 exit 1
 
-set "PATH=%PATH%;%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin"
+@REM set "PATH=%PATH%;%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin"
+
+set "PYTHONPATH=%GIR_PREFIX%\Lib\site-packages;%PYTHONPATH%"
+set "PATH=%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin;%GIR_PREFIX%\Library\usr\bin;%PATH%"
 
 mkdir forgebuild
 cd forgebuild

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -24,7 +24,7 @@ set "CPPFLAGS=%CPPFLAGS% -D^"%LIBRARY_PREFIX_M%^""
 mkdir forgebuild
 cd forgebuild
 
-meson setup --buildtype=release --prefix="%LIBRARY_PREFIX_M%" --backend=ninja -Dselinux=disabled -Dxattr=false -Dlibmount=disabled ..
+meson setup --buildtype=release --prefix="%LIBRARY_PREFIX_M%" --backend=ninja -Dselinux=disabled -Dxattr=false -Dlibmount=disabled -Dintrospection=enabled ..
 if errorlevel 1 (
   type forgebuild\meson-logs\meson-log.txt
   exit /b 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,8 +13,6 @@ set "GIR_PREFIX=%cd%\g-ir-prefix"
 call conda create -p %GIR_PREFIX% -y -c conda-forge -c defaults "python=%PY_VER%" g-ir-build-tools gobject-introspection glib "setuptools<71"
 if errorlevel 1 exit 1
 
-@REM set "PATH=%PATH%;%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin"
-
 set "PYTHONPATH=%GIR_PREFIX%\Lib\site-packages;%PYTHONPATH%"
 set "PATH=%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin;%GIR_PREFIX%\Library\usr\bin;%PATH%"
 
@@ -29,9 +27,6 @@ set PKG_CONFIG_PATH=%LIBRARY_PREFIX_M%/lib/pkgconfig;%LIBRARY_PREFIX_M%/share/pk
 @REM Avoid a Meson issue - https://github.com/mesonbuild/meson/issues/4827
 set "PYTHONLEGACYWINDOWSSTDIO=1"
 set "PYTHONIOENCODING=UTF-8"
-
-@REM See hardcoded-paths.patch
-set "CPPFLAGS=%CPPFLAGS% -D^"%LIBRARY_PREFIX_M%^""
 
 meson setup --buildtype=release --prefix="%LIBRARY_PREFIX_M%" --backend=ninja -Dselinux=disabled -Dxattr=false -Dlibmount=disabled -Dintrospection=enabled ..
 if errorlevel 1 (

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,10 +10,16 @@ echo none /tmp usertemp binary,posix=0 0 0 >>%BUILD_PREFIX%\Library\etc\fstab
 
 set "GIR_PREFIX=%cd%\g-ir-prefix"
 
-@REM call conda create -p %GIR_PREFIX% -y -c conda-forge -c defaults "python=%PY_VER%" g-ir-build-tools gobject-introspection glib "setuptools<71"
-@REM if errorlevel 1 exit 1
-
-call conda create -p %GIR_PREFIX% -y "python=%PY_VER%" gobject-introspection glib "setuptools<71"
+REM NOTE:
+REM gobject-introspection (g-ir-scanner) is used here strictly as a *build-time tool*.
+REM On Windows, using the target Python version (e.g. 3.14) often fails to resolve
+REM a compatible dependency set (libffi / python_abi / gobject-introspection).
+REM
+REM To keep the build reliable and deterministic, we pin a known-good Python
+REM version (3.12) for the GIR build environment. The generated GIR/typelib
+REM artifacts are Python-version-independent and safe to use for all outputs.
+set "GIR_PY=3.12"
+call conda create -p %GIR_PREFIX% -y "python=%GIR_PY%" gobject-introspection glib "setuptools<71"
 if errorlevel 1 exit 1
 
 set "PYTHONPATH=%GIR_PREFIX%\Lib\site-packages;%PYTHONPATH%"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -47,7 +47,21 @@ export PKG_CONFIG_PATH="$GIR_PREFIX/lib/pkgconfig:$GIR_PREFIX/share/pkgconfig:${
 
 
 # --- make sure pkg-config sees host/build deps (esp. pcre2) ---
-export PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
+# export PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
+
+
+# --- pkg-config (safe, no recursion) ---
+# Prefer an existing pkg-config in PATH
+if command -v pkg-config >/dev/null 2>&1; then
+  export PKG_CONFIG="$(command -v pkg-config)"
+fi
+
+# If PKG_CONFIG ends up pointing to BUILD_PREFIX/bin/pkg-config, make sure it's not a wrapper to itself
+if [[ -n "${PKG_CONFIG:-}" && "${PKG_CONFIG}" == "${BUILD_PREFIX}/bin/pkg-config" ]]; then
+  # If it's not executable or suspicious, just unset and let Meson find it via PATH
+  [[ -x "${PKG_CONFIG}" ]] || unset PKG_CONFIG
+fi
+# --- end pkg-config ---
 
 
 export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig:${PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH:-}"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,11 +22,6 @@ if [[ -n "${build_platform:-}" ]]; then
   export CONDA_SUBDIR="${build_platform}"
 fi
 
-# conda create -p "$GIR_PREFIX" -y \
-#   -c conda-forge -c defaults \
-#   "python=${PY_VER}" \
-#   g-ir-build-tools gobject-introspection
-
 conda create -p "$GIR_PREFIX" -y \
   "python=${PY_VER}" \
   gobject-introspection

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,7 +20,7 @@ unset _CONDA_PYTHON_SYSCONFIGDATA_NAME
 # * https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/433
 # * https://gitlab.gnome.org/GNOME/glib/-/issues/2616
 export GIR_PREFIX=$(pwd)/g-ir-prefix
-conda create -p ${GIR_PREFIX} -y g-ir-build-tools gobject-introspection
+conda create -p ${GIR_PREFIX} -y -c conda-forge g-ir-build-tools gobject-introspection
 
 cat <<EOF > $BUILD_PREFIX/bin/g-ir-scanner
 #!/bin/bash

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,10 +22,14 @@ if [[ -n "${build_platform:-}" ]]; then
   export CONDA_SUBDIR="${build_platform}"
 fi
 
+# conda create -p "$GIR_PREFIX" -y \
+#   -c conda-forge -c defaults \
+#   "python=${PY_VER}" \
+#   g-ir-build-tools gobject-introspection
+
 conda create -p "$GIR_PREFIX" -y \
-  -c conda-forge -c defaults \
   "python=${PY_VER}" \
-  g-ir-build-tools gobject-introspection
+  gobject-introspection
 
 unset CONDA_SUBDIR
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -59,9 +59,8 @@ if [[ -n "${GIR_PREFIX:-}" ]]; then
 fi
 
 # DEBUG: Check libs
-${PKG_CONFIG} --exists libpcre2-8
-${PKG_CONFIG} --libs libpcre2-8
-# --- end ---
+# ${PKG_CONFIG} --exists libpcre2-8
+# ${PKG_CONFIG} --libs libpcre2-8
 
 ###########################
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,6 +15,20 @@ export PYTHON="python"
 # see for context: https://github.com/conda-forge/glib-feedstock/pull/72 https://github.com/conda-forge/python-feedstock/issues/474
 unset _CONDA_PYTHON_SYSCONFIGDATA_NAME
 
+# There is currently a cyclic dependency between glib and gobject-introspection:
+# * https://discourse.gnome.org/t/dealing-with-glib-and-gobject-introspection-circular-dependency/18701
+# * https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/433
+# * https://gitlab.gnome.org/GNOME/glib/-/issues/2616
+export GIR_PREFIX=$(pwd)/g-ir-prefix
+conda create -p ${GIR_PREFIX} -y g-ir-build-tools gobject-introspection
+
+cat <<EOF > $BUILD_PREFIX/bin/g-ir-scanner
+#!/bin/bash
+
+exec ${GIR_PREFIX}/bin/g-ir-scanner \$*
+EOF
+chmod +x $BUILD_PREFIX/bin/g-ir-scanner
+
 export PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
 export PKG_CONFIG_PATH="${BUILD_PREFIX}/lib/pkgconfig:${BUILD_PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH:-}"
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,8 +15,6 @@ export PYTHON="python"
 # see for context: https://github.com/conda-forge/glib-feedstock/pull/72 https://github.com/conda-forge/python-feedstock/issues/474
 unset _CONDA_PYTHON_SYSCONFIGDATA_NAME
 
-###########################
-
 # ---- gobject-introspection bootstrap (build-platform tools) ----
 export GIR_PREFIX="$SRC_DIR/g-ir-prefix"
 
@@ -34,23 +32,14 @@ unset CONDA_SUBDIR
 # Check, if g-ir-scanner run
 "$GIR_PREFIX/bin/g-ir-scanner" --version
 
-
 cat > "$BUILD_PREFIX/bin/g-ir-scanner" <<EOF
 #!/usr/bin/env bash
 exec "$GIR_PREFIX/bin/g-ir-scanner" "\$@"
 EOF
 chmod +x "$BUILD_PREFIX/bin/g-ir-scanner"
 
-
 export PKG_CONFIG_PATH="$GIR_PREFIX/lib/pkgconfig:$GIR_PREFIX/share/pkgconfig:${PKG_CONFIG_PATH:-}"
-# ---- end bootstrap ----
 
-
-# --- make sure pkg-config sees host/build deps (esp. pcre2) ---
-# export PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
-
-
-# --- pkg-config (safe, no recursion) ---
 # Prefer an existing pkg-config in PATH
 if command -v pkg-config >/dev/null 2>&1; then
   export PKG_CONFIG="$(command -v pkg-config)"
@@ -61,22 +50,17 @@ if [[ -n "${PKG_CONFIG:-}" && "${PKG_CONFIG}" == "${BUILD_PREFIX}/bin/pkg-config
   # If it's not executable or suspicious, just unset and let Meson find it via PATH
   [[ -x "${PKG_CONFIG}" ]] || unset PKG_CONFIG
 fi
-# --- end pkg-config ---
-
 
 export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig:${PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH:-}"
 export PKG_CONFIG_PATH="${BUILD_PREFIX}/lib/pkgconfig:${BUILD_PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH}"
-
 
 if [[ -n "${GIR_PREFIX:-}" ]]; then
   export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${GIR_PREFIX}/lib/pkgconfig:${GIR_PREFIX}/share/pkgconfig"
 fi
 
-# DEBUG: Check libs
+# DEBUG
 # ${PKG_CONFIG} --exists libpcre2-8
 # ${PKG_CONFIG} --libs libpcre2-8
-
-###########################
 
 mkdir -p builddir
 meson setup builddir \
@@ -92,6 +76,7 @@ meson setup builddir \
   -Ddtrace=false \
   -Dsystemtap=false \
   || { cat "$SRC_DIR"/builddir/meson-logs/meson-log.txt ; exit 1 ; }
+
 ninja -C builddir -j${CPU_COUNT} -v
 
 if [ "${target_platform}" == 'linux-aarch64' ]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,19 +15,23 @@ export PYTHON="python"
 # see for context: https://github.com/conda-forge/glib-feedstock/pull/72 https://github.com/conda-forge/python-feedstock/issues/474
 unset _CONDA_PYTHON_SYSCONFIGDATA_NAME
 
+export PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
+export PKG_CONFIG_PATH="${BUILD_PREFIX}/lib/pkgconfig:${BUILD_PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH:-}"
+
 mkdir -p builddir
 meson setup builddir \
   --buildtype=release \
   --prefix="$PREFIX" \
   --backend=ninja \
   -Dlibdir=lib \
+  -Dintrospection=enabled \
   -Dlocalstatedir="$PREFIX/var" \
   -Dlibmount=disabled \
   -Dselinux=disabled \
   -Dxattr=false \
   -Ddtrace=false \
   -Dsystemtap=false \
-  || { cat meson-logs/meson-log.txt ; exit 1 ; }
+  || { cat "$SRC_DIR"/builddir/meson-logs/meson-log.txt ; exit 1 ; }
 ninja -C builddir -j${CPU_COUNT} -v
 
 if [ "${target_platform}" == 'linux-aarch64' ]; then

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -3,26 +3,77 @@
 set -ex
 
 
-export PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
-export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig:${PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH:-}"
-export PKG_CONFIG_PATH="${BUILD_PREFIX}/lib/pkgconfig:${BUILD_PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH}"
+# --- pkg-config (CI-safe; prefers conda build env; macOS-friendly) ---
+# Put fixes under this wrapper exactly as you asked
+if [ "${target_platform}" = osx-* ]; then
+  # Prefer conda-build tools, not system/homebrew.
+  # conda-build usually provides tools in BUILD_PREFIX/bin (a.k.a. _build_env/bin)
+  REAL_PKG_CONFIG=""
+
+  # 1) Most common: pkg-config exists in build env
+  if [ -x "${BUILD_PREFIX}/bin/pkg-config" ]; then
+    REAL_PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
+  # 2) Sometimes only pkgconf exists (no pkg-config alias)
+  elif [ -x "${BUILD_PREFIX}/bin/pkgconf" ]; then
+    REAL_PKG_CONFIG="${BUILD_PREFIX}/bin/pkgconf"
+  # 3) Fallback: host prefix (less likely during install stage, but cheap to try)
+  elif [ -x "${PREFIX}/bin/pkg-config" ]; then
+    REAL_PKG_CONFIG="${PREFIX}/bin/pkg-config"
+  elif [ -x "${PREFIX}/bin/pkgconf" ]; then
+    REAL_PKG_CONFIG="${PREFIX}/bin/pkgconf"
+  # 4) Last resort: PATH (may be empty on CI, but ok locally)
+  elif command -v pkg-config >/dev/null 2>&1; then
+    REAL_PKG_CONFIG="$(command -v pkg-config)"
+  elif command -v pkgconf >/dev/null 2>&1; then
+    REAL_PKG_CONFIG="$(command -v pkgconf)"
+  fi
+
+  if [ -z "${REAL_PKG_CONFIG}" ]; then
+    echo "ERROR: pkg-config/pkgconf not found."
+    echo "DEBUG: target_platform=${target_platform}"
+    echo "DEBUG: BUILD_PREFIX=${BUILD_PREFIX}"
+    echo "DEBUG: PREFIX=${PREFIX}"
+    echo "DEBUG: PATH=${PATH}"
+    echo "DEBUG: ls BUILD_PREFIX/bin:"
+    ls -la "${BUILD_PREFIX}/bin" || true
+    echo "DEBUG: ls PREFIX/bin:"
+    ls -la "${PREFIX}/bin" || true
+    exit 1
+  fi
+
+  # Ensure Meson (and any subprocess) can always execute "pkg-config"
+  mkdir -p "${BUILD_PREFIX}/bin"
+  cat > "${BUILD_PREFIX}/bin/pkg-config" <<EOF
+#!/usr/bin/env sh
+exec "${REAL_PKG_CONFIG}" "\$@"
+EOF
+  chmod +x "${BUILD_PREFIX}/bin/pkg-config"
+
+  export PATH="${BUILD_PREFIX}/bin:${PATH}"
+  export PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
+
+  # Keep pkg-config search paths sane in multi-output install stage
+  export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig:${PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH:-}"
+  export PKG_CONFIG_PATH="${BUILD_PREFIX}/lib/pkgconfig:${BUILD_PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH}"
+fi
+# --- end pkg-config block ---
 
 # --- Make sure Meson-cached pkg-config path exists (multi-output install stage) ---
-if command -v pkg-config >/dev/null 2>&1; then
-  REAL_PKG_CONFIG=$(command -v pkg-config)
-else
-  echo "ERROR: pkg-config not found in PATH"
-  exit 1
-fi
+# if command -v pkg-config >/dev/null 2>&1; then
+#   REAL_PKG_CONFIG=$(command -v pkg-config)
+# else
+#   echo "ERROR: pkg-config not found in PATH"
+#   exit 1
+# fi
 
 # Meson in your logs tries: .../_build_env/bin/pkg-config
 # In install stage BUILD_PREFIX may be that _build_env prefix.
-mkdir -p "${BUILD_PREFIX}/bin"
-cat > "${BUILD_PREFIX}/bin/pkg-config" <<EOF
-#!/usr/bin/env bash
-exec "${REAL_PKG_CONFIG}" "\$@"
-EOF
-chmod +x "${BUILD_PREFIX}/bin/pkg-config"
+# mkdir -p "${BUILD_PREFIX}/bin"
+# cat > "${BUILD_PREFIX}/bin/pkg-config" <<EOF
+# #!/usr/bin/env bash
+# exec "${REAL_PKG_CONFIG}" "\$@"
+# EOF
+# chmod +x "${BUILD_PREFIX}/bin/pkg-config"
 
 # Put it first, so any subprocesses also see it
 export PATH="${BUILD_PREFIX}/bin:${PATH}"

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+export PATH="${BUILD_PREFIX}/bin:${PATH}"
+
 # --- Make sure Meson-cached pkg-config path exists (multi-output install stage) ---
 if command -v pkg-config >/dev/null 2>&1; then
   REAL_PKG_CONFIG=$(command -v pkg-config)

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -2,15 +2,33 @@
 
 set -ex
 
+#!/bin/bash
+set -ex
+
 export PATH="${BUILD_PREFIX}/bin:${PATH}"
 
-# --- Make sure Meson-cached pkg-config path exists (multi-output install stage) ---
-if command -v pkg-config >/dev/null 2>&1; then
-  REAL_PKG_CONFIG=$(command -v pkg-config)
+if REAL_PKG_CONFIG="$(command -v pkg-config 2>/dev/null)"; then
+  :
+elif [ -x "${BUILD_PREFIX}/bin/pkg-config" ]; then
+  REAL_PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
+elif [ -x "${PREFIX}/bin/pkg-config" ]; then
+  REAL_PKG_CONFIG="${PREFIX}/bin/pkg-config"
 else
-  echo "ERROR: pkg-config not found in PATH"
+  echo "ERROR: pkg-config not found. PATH=${PATH}" >&2
+  echo "DEBUG: BUILD_PREFIX=${BUILD_PREFIX}" >&2
+  echo "DEBUG: PREFIX=${PREFIX}" >&2
+  ls -la "${BUILD_PREFIX}/bin" 2>/dev/null || true
+  ls -la "${PREFIX}/bin" 2>/dev/null || true
   exit 1
 fi
+
+# --- Make sure Meson-cached pkg-config path exists (multi-output install stage) ---
+# if command -v pkg-config >/dev/null 2>&1; then
+#   REAL_PKG_CONFIG=$(command -v pkg-config)
+# else
+#   echo "ERROR: pkg-config not found in PATH"
+#   exit 1
+# fi
 
 # Meson in your logs tries: .../_build_env/bin/pkg-config
 # In install stage BUILD_PREFIX may be that _build_env prefix.

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -8,11 +8,15 @@ export PATH="${BUILD_PREFIX}/bin:${PATH}"
 # Bootstrap gobject-introspection tools (without touching meta.yaml)
 export GIR_PREFIX="${SRC_DIR}/g-ir-prefix"
 
+# if [[ ! -x "${GIR_PREFIX}/bin/g-ir-scanner" ]]; then
+#   conda create -p "${GIR_PREFIX}" -y \
+#     -c conda-forge -c defaults \
+#     python gobject-introspection g-ir-build-tools
+# fi
+
 if [[ ! -x "${GIR_PREFIX}/bin/g-ir-scanner" ]]; then
-  # g-ir-build-tools есть только в conda-forge
   conda create -p "${GIR_PREFIX}" -y \
-    -c conda-forge -c defaults \
-    python gobject-introspection g-ir-build-tools
+    "python=${PY_VER}" gobject-introspection
 fi
 
 # Make g-ir-scanner available in PATH (Meson looking it there)

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -3,8 +3,8 @@
 set -ex
 
 # --- Make sure Meson-cached pkg-config path exists (multi-output install stage) ---
-REAL_PKG_CONFIG="$(command -v pkg-config)"
-if [[ -z "${REAL_PKG_CONFIG}" ]]; then
+REAL_PKG_CONFIG=$(command -v pkg-config 2>/dev/null)
+if [ -z "$REAL_PKG_CONFIG" ]; then
   echo "ERROR: pkg-config not found in PATH"
   exit 1
 fi

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -3,8 +3,9 @@
 set -ex
 
 # --- Make sure Meson-cached pkg-config path exists (multi-output install stage) ---
-REAL_PKG_CONFIG=$(command -v pkg-config 2>/dev/null)
-if [ -z "$REAL_PKG_CONFIG" ]; then
+if command -v pkg-config >/dev/null 2>&1; then
+  REAL_PKG_CONFIG=$(command -v pkg-config)
+else
   echo "ERROR: pkg-config not found in PATH"
   exit 1
 fi

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -8,12 +8,6 @@ export PATH="${BUILD_PREFIX}/bin:${PATH}"
 # Bootstrap gobject-introspection tools (without touching meta.yaml)
 export GIR_PREFIX="${SRC_DIR}/g-ir-prefix"
 
-# if [[ ! -x "${GIR_PREFIX}/bin/g-ir-scanner" ]]; then
-#   conda create -p "${GIR_PREFIX}" -y \
-#     -c conda-forge -c defaults \
-#     python gobject-introspection g-ir-build-tools
-# fi
-
 if [[ ! -x "${GIR_PREFIX}/bin/g-ir-scanner" ]]; then
   conda create -p "${GIR_PREFIX}" -y \
     "python=${PY_VER}" gobject-introspection

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -2,33 +2,18 @@
 
 set -ex
 
-#!/bin/bash
-set -ex
 
-export PATH="${BUILD_PREFIX}/bin:${PATH}"
-
-if REAL_PKG_CONFIG="$(command -v pkg-config 2>/dev/null)"; then
-  :
-elif [ -x "${BUILD_PREFIX}/bin/pkg-config" ]; then
-  REAL_PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
-elif [ -x "${PREFIX}/bin/pkg-config" ]; then
-  REAL_PKG_CONFIG="${PREFIX}/bin/pkg-config"
-else
-  echo "ERROR: pkg-config not found. PATH=${PATH}" >&2
-  echo "DEBUG: BUILD_PREFIX=${BUILD_PREFIX}" >&2
-  echo "DEBUG: PREFIX=${PREFIX}" >&2
-  ls -la "${BUILD_PREFIX}/bin" 2>/dev/null || true
-  ls -la "${PREFIX}/bin" 2>/dev/null || true
-  exit 1
-fi
+export PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
+export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig:${PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH:-}"
+export PKG_CONFIG_PATH="${BUILD_PREFIX}/lib/pkgconfig:${BUILD_PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH}"
 
 # --- Make sure Meson-cached pkg-config path exists (multi-output install stage) ---
-# if command -v pkg-config >/dev/null 2>&1; then
-#   REAL_PKG_CONFIG=$(command -v pkg-config)
-# else
-#   echo "ERROR: pkg-config not found in PATH"
-#   exit 1
-# fi
+if command -v pkg-config >/dev/null 2>&1; then
+  REAL_PKG_CONFIG=$(command -v pkg-config)
+else
+  echo "ERROR: pkg-config not found in PATH"
+  exit 1
+fi
 
 # Meson in your logs tries: .../_build_env/bin/pkg-config
 # In install stage BUILD_PREFIX may be that _build_env prefix.

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -2,29 +2,10 @@
 
 set -ex
 
-
-# --- Make sure Meson-cached pkg-config path exists (multi-output install stage) ---
-# if command -v pkg-config >/dev/null 2>&1; then
-#   REAL_PKG_CONFIG=$(command -v pkg-config)
-# else
-#   echo "ERROR: pkg-config not found in PATH"
-#   exit 1
-# fi
-
-# Meson in your logs tries: .../_build_env/bin/pkg-config
-# In install stage BUILD_PREFIX may be that _build_env prefix.
-# mkdir -p "${BUILD_PREFIX}/bin"
-# cat > "${BUILD_PREFIX}/bin/pkg-config" <<EOF
-# #!/usr/bin/env bash
-# exec "${REAL_PKG_CONFIG}" "\$@"
-# EOF
-# chmod +x "${BUILD_PREFIX}/bin/pkg-config"
-
 # Put it first, so any subprocesses also see it
 export PATH="${BUILD_PREFIX}/bin:${PATH}"
-# --- end ---
 
-# 2. Bootstrap gobject-introspection tools (without touching meta.yaml)
+# Bootstrap gobject-introspection tools (without touching meta.yaml)
 export GIR_PREFIX="${SRC_DIR}/g-ir-prefix"
 
 if [[ ! -x "${GIR_PREFIX}/bin/g-ir-scanner" ]]; then
@@ -34,7 +15,7 @@ if [[ ! -x "${GIR_PREFIX}/bin/g-ir-scanner" ]]; then
     python gobject-introspection g-ir-build-tools
 fi
 
-# 3. Make g-ir-scanner available in PATH (Meson looking it there)
+# Make g-ir-scanner available in PATH (Meson looking it there)
 mkdir -p "${BUILD_PREFIX}/bin"
 cat > "${BUILD_PREFIX}/bin/g-ir-scanner" <<'EOF'
 #!/usr/bin/env bash
@@ -44,22 +25,19 @@ chmod +x "${BUILD_PREFIX}/bin/g-ir-scanner"
 
 export PATH="${BUILD_PREFIX}/bin:${PATH}"
 
-# 4. For Meson to help find gobject-introspection-1.0.pc
+# For Meson to help find gobject-introspection-1.0.pc
 export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig:${PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH:-}"
 if [[ -d "${GIR_PREFIX}/lib/pkgconfig" ]]; then
   export PKG_CONFIG_PATH="${GIR_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 fi
 
-# --- end ---
-
-
+# DEBUG
 # echo "PKG_CONFIG=$PKG_CONFIG"
 # $PKG_CONFIG --version
 # $PKG_CONFIG --modversion gobject-introspection-1.0 || true
 # $PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0 || true
 # which g-ir-scanner
 # g-ir-scanner --version
-# exit 1
 
 unset _CONDA_PYTHON_SYSCONFIGDATA_NAME
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ source:
     - patches/0007-disable-test_fork_fail.patch  # [linux]
 
 build:
-  number: 0
+  number: 1
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
   skip: True  # [py<37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ build:
   number: 0
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
-  skip: True  # [py<37 or linux or win]
+  skip: True  # [py<37 or osx or win]
 
 requirements:
   build:
@@ -76,7 +76,7 @@ outputs:
       build:
         - meson >=1.4.0
         - ninja-base
-        - pkg-config  # [osx]
+        - pkg-config
         - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
@@ -121,7 +121,7 @@ outputs:
       build:
         - meson >=1.4.0
         - ninja-base
-        - pkg-config  # [osx]
+        - pkg-config
         - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
@@ -153,7 +153,7 @@ outputs:
       build:
         - meson >=1.4.0
         - ninja-base
-        - pkg-config  # [osx]
+        - pkg-config
         - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -98,9 +98,10 @@ outputs:
 
     test:
       commands:
+        - echo "-------START-TEST-------"  # [win]
         - test -f ${PREFIX}/lib/libglib-2.0.0{{ SHLIB_EXT }}  # [osx]
         - test -f ${PREFIX}/lib/libglib-2.0{{ SHLIB_EXT }}.0  # [linux]
-        - if not exist "%LIBRARY_BIN%\\glib-2.0-0.dll" exit 1 # [win]
+        - if not exist "%LIBRARY_BIN%\\glib-2.0-0.dll" exit 1  # [win]
         - if not exist "%LIBRARY_LIB%\\glib-2.0.lib" exit 1   # [win]
         - test ! -f ${PREFIX}/lib/libgobject-2.0.la  # [not win]
         - test ! -f ${PREFIX}/lib/libglib-2.0${SHLIB_EXT}  # [not win]
@@ -112,6 +113,7 @@ outputs:
         - test -f ${PREFIX}/lib/girepository-1.0/GLib-2.0.typelib   # [unix]
         - if not exist %LIBRARY_PREFIX%\share\gir-1.0\GLib-2.0.gir exit 1             # [win]
         - if not exist %LIBRARY_PREFIX%\lib\girepository-1.0\GLib-2.0.typelib exit 1  # [win]
+        - echo "-------START-TEST-------"  # [win]
 
   - name: glib-tools
     script: install.sh  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ build:
   number: 0
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
-  skip: True  # [py<37]
+  skip: True  # [py<37 or osx or linux]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,6 +74,7 @@ outputs:
         - {{ pin_subpackage("libglib") }}
     requirements:
       build:
+        - pkg-config
         - meson >=1.4.0
         - ninja-base
         - {{ stdlib('c') }}
@@ -118,6 +119,7 @@ outputs:
     build:
     requirements:
       build:
+        - pkg-config
         - meson >=1.4.0
         - ninja-base
         - {{ stdlib('c') }}
@@ -149,6 +151,7 @@ outputs:
         - {{ pin_subpackage("libglib") }}
     requirements:
       build:
+        - pkg-config
         - meson >=1.4.0
         - ninja-base
         - {{ stdlib('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ build:
   number: 0
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
-  skip: True  # [py<37 or win]
+  skip: True  # [py<37 or linux or win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ build:
   number: 0
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
-  skip: True  # [py<37 or osx or linux]
+  skip: True  # [py<37]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,7 +86,7 @@ outputs:
         - gettext {{ gettext }}  # [osx]
         - zlib {{ zlib }}
         - pcre2 {{ pcre2 }}
-        - libiconv {{ libiconv }}
+        - libiconv
       run:
         - gettext >=0.21.0,<1.0a0  # [osx]
         # bounds through run_exports

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,11 +107,11 @@ outputs:
         - test -f ${PREFIX}/lib/pkgconfig/glib-2.0.pc  # [unix]
         - test -f ${PREFIX}/etc/conda/activate.d/libglib_activate.sh  # [not win]
         - test -f ${PREFIX}/etc/conda/deactivate.d/libglib_deactivate.sh  # [not win]
-        # Introspection data is needed at runtime
+        # Introspection test
         - test -f ${PREFIX}/share/gir-1.0/GLib-2.0.gir              # [unix]
         - test -f ${PREFIX}/lib/girepository-1.0/GLib-2.0.typelib   # [unix]
-        # - if not exist %LIBRARY_PREFIX%\share\gir-1.0\GLib-2.0.gir exit 1             # [win]
-        # - if not exist %LIBRARY_PREFIX%\lib\girepository-1.0\GLib-2.0.typelib exit 1  # [win]
+        - if not exist %LIBRARY_PREFIX%\share\gir-1.0\GLib-2.0.gir exit 1             # [win]
+        - if not exist %LIBRARY_PREFIX%\lib\girepository-1.0\GLib-2.0.typelib exit 1  # [win]
 
   - name: glib-tools
     script: install.sh  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ source:
     - patches/0007-disable-test_fork_fail.patch  # [linux]
 
 build:
-  number: 1
+  number: 0
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
   skip: True  # [py<37]
@@ -96,9 +96,7 @@ outputs:
         - zlib
         - pcre2
         - libiconv
-      run_constrained:
-        # Avoid colliding with older glib builds that didn't have a libglib output
-        - glib {{ version }} *_{{ PKG_BUILDNUM }}
+
     test:
       commands:
         - test -f ${PREFIX}/lib/libglib-2.0.0{{ SHLIB_EXT }}  # [osx]
@@ -122,7 +120,6 @@ outputs:
     build:
     requirements:
       build:
-        - gobject-introspection
         - meson >=1.4.0
         - ninja-base
         - {{ stdlib('c') }}
@@ -132,9 +129,9 @@ outputs:
         - setuptools
         - gettext {{ gettext }}  # [osx]
       host:
-        - {{ pin_subpackage("libglib", exact=True) }}
+        - {{ pin_subpackage("libglib", skip_build_id=True) }}
       run:
-        - {{ pin_subpackage("libglib", exact=True) }}
+        - {{ pin_subpackage("libglib", skip_build_id=True) }}
         - gettext >=0.21.0,<1.0a0  # [osx]
     test:
       commands:
@@ -154,7 +151,6 @@ outputs:
         - {{ pin_subpackage("libglib") }}
     requirements:
       build:
-        - gobject-introspection
         - meson >=1.4.0
         - ninja-base
         - {{ stdlib('c') }}
@@ -163,14 +159,14 @@ outputs:
         - python
         - setuptools
       host:
-        - {{ pin_subpackage("libglib", exact=True) }}
-        - {{ pin_subpackage("glib-tools", exact=True) }}
+        - {{ pin_subpackage("libglib", skip_build_id=True) }}
+        - {{ pin_subpackage("glib-tools", skip_build_id=True) }}
         - gettext {{ gettext }}  # [osx]
       run:
         - python
         - gettext >=0.21.0,<1.0a0  # [osx]
-        - {{ pin_subpackage("libglib", exact=True) }}
-        - {{ pin_subpackage("glib-tools", exact=True) }}
+        - {{ pin_subpackage("libglib", skip_build_id=True) }}
+        - {{ pin_subpackage("glib-tools", skip_build_id=True) }}
     test:
       commands:
         - test -f ${PREFIX}/lib/libglib-2.0${SHLIB_EXT}  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ build:
   number: 0
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
-  skip: True  # [py<37 or linux]
+  # skip: True  # [py<37]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ build:
   number: 0
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
-  skip: True  # [py<37 or osx or linux]
+  skip: True  # [py<37 or linux or win]
 
 requirements:
   build:
@@ -87,7 +87,7 @@ outputs:
         - gettext {{ gettext }}  # [osx]
         - zlib {{ zlib }}
         - pcre2 {{ pcre2 }}
-        - libiconv
+        - libiconv {{ libiconv }}
       run:
         - gettext >=0.21.0,<1.0a0  # [osx]
         # bounds through run_exports

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ build:
   number: 0
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
-  skip: True  # [py<37 or osx or win]
+  skip: True  # [py<37 or osx or linux]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ build:
   number: 0
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
-  skip: True  # [py<37 or osx or win]
+  skip: True  # [py<37 or win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,10 +107,10 @@ outputs:
         - test -f ${PREFIX}/etc/conda/activate.d/libglib_activate.sh  # [not win]
         - test -f ${PREFIX}/etc/conda/deactivate.d/libglib_deactivate.sh  # [not win]
         # Introspection data is needed at runtime
-        # - test -f ${PREFIX}/share/gir-1.0/GLib-2.0.gir              # [unix]
-        # - test -f ${PREFIX}/lib/girepository-1.0/GLib-2.0.typelib   # [unix]
-        # - if not exist %LIBRARY_PREFIX%\share\gir-1.0\GLib-2.0.gir exit 1             # [win]
-        # - if not exist %LIBRARY_PREFIX%\lib\girepository-1.0\GLib-2.0.typelib exit 1  # [win]
+        - test -f ${PREFIX}/share/gir-1.0/GLib-2.0.gir              # [unix]
+        - test -f ${PREFIX}/lib/girepository-1.0/GLib-2.0.typelib   # [unix]
+        - if not exist %LIBRARY_PREFIX%\share\gir-1.0\GLib-2.0.gir exit 1             # [win]
+        - if not exist %LIBRARY_PREFIX%\lib\girepository-1.0\GLib-2.0.typelib exit 1  # [win]
 
   - name: glib-tools
     script: install.sh  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ build:
   number: 0
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
-  skip: True  # [py<37 or linux or win]
+  skip: True  # [py<37 or osx or win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,7 +76,7 @@ outputs:
       build:
         - meson >=1.4.0
         - ninja-base
-        - pkg-config
+        - pkg-config  # [not win]
         - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
@@ -121,7 +121,7 @@ outputs:
       build:
         - meson >=1.4.0
         - ninja-base
-        - pkg-config
+        - pkg-config  # [not win]
         - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
@@ -153,7 +153,7 @@ outputs:
       build:
         - meson >=1.4.0
         - ninja-base
-        - pkg-config
+        - pkg-config  # [not win]
         - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ build:
   number: 0
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
-  skip: True  # [py<37]
+  skip: True  # [py<37 or linux]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,11 +36,10 @@ build:
   number: 0
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
-  # skip: True  # [py<37]
+  skip: True  # [py<37]
 
 requirements:
   build:
-    - gobject-introspection
     - meson >=1.4.0
     - cmake
     - ninja-base
@@ -75,7 +74,6 @@ outputs:
         - {{ pin_subpackage("libglib") }}
     requirements:
       build:
-        - gobject-introspection
         - meson >=1.4.0
         - ninja-base
         - {{ stdlib('c') }}
@@ -109,10 +107,10 @@ outputs:
         - test -f ${PREFIX}/etc/conda/activate.d/libglib_activate.sh  # [not win]
         - test -f ${PREFIX}/etc/conda/deactivate.d/libglib_deactivate.sh  # [not win]
         # Introspection data is needed at runtime
-        - test -f ${PREFIX}/share/gir-1.0/GLib-2.0.gir              # [unix]
-        - test -f ${PREFIX}/lib/girepository-1.0/GLib-2.0.typelib   # [unix]
-        - if not exist %LIBRARY_PREFIX%\share\gir-1.0\GLib-2.0.gir exit 1             # [win]
-        - if not exist %LIBRARY_PREFIX%\lib\girepository-1.0\GLib-2.0.typelib exit 1  # [win]
+        # - test -f ${PREFIX}/share/gir-1.0/GLib-2.0.gir              # [unix]
+        # - test -f ${PREFIX}/lib/girepository-1.0/GLib-2.0.typelib   # [unix]
+        # - if not exist %LIBRARY_PREFIX%\share\gir-1.0\GLib-2.0.gir exit 1             # [win]
+        # - if not exist %LIBRARY_PREFIX%\lib\girepository-1.0\GLib-2.0.typelib exit 1  # [win]
 
   - name: glib-tools
     script: install.sh  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,7 +101,9 @@ outputs:
         - echo "-------START-TEST-------"  # [win]
         - test -f ${PREFIX}/lib/libglib-2.0.0{{ SHLIB_EXT }}  # [osx]
         - test -f ${PREFIX}/lib/libglib-2.0{{ SHLIB_EXT }}.0  # [linux]
+        - echo "STEP 1"  # [win]
         - if not exist "%LIBRARY_BIN%\\glib-2.0-0.dll" exit 1  # [win]
+        - echo "STEP 2"  # [win]
         - if not exist "%LIBRARY_LIB%\\glib-2.0.lib" exit 1   # [win]
         - test ! -f ${PREFIX}/lib/libgobject-2.0.la  # [not win]
         - test ! -f ${PREFIX}/lib/libglib-2.0${SHLIB_EXT}  # [not win]
@@ -111,7 +113,9 @@ outputs:
         # Introspection data is needed at runtime
         - test -f ${PREFIX}/share/gir-1.0/GLib-2.0.gir              # [unix]
         - test -f ${PREFIX}/lib/girepository-1.0/GLib-2.0.typelib   # [unix]
+        - echo "STEP 3"  # [win]
         - if not exist %LIBRARY_PREFIX%\share\gir-1.0\GLib-2.0.gir exit 1             # [win]
+        - echo "STEP 4"  # [win]
         - if not exist %LIBRARY_PREFIX%\lib\girepository-1.0\GLib-2.0.typelib exit 1  # [win]
         - echo "-------START-TEST-------"  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ build:
   number: 0
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
-  skip: True  # [py<37 or osx or win]
+  skip: True  # [py<37]
 
 requirements:
   build:
@@ -87,7 +87,7 @@ outputs:
         - gettext {{ gettext }}  # [osx]
         - zlib {{ zlib }}
         - pcre2 {{ pcre2 }}
-        - libiconv {{ libiconv }}
+        - libiconv
       run:
         - gettext >=0.21.0,<1.0a0  # [osx]
         # bounds through run_exports
@@ -98,12 +98,9 @@ outputs:
 
     test:
       commands:
-        - echo "-------START-TEST-------"  # [win]
         - test -f ${PREFIX}/lib/libglib-2.0.0{{ SHLIB_EXT }}  # [osx]
         - test -f ${PREFIX}/lib/libglib-2.0{{ SHLIB_EXT }}.0  # [linux]
-        - echo "STEP 1"  # [win]
         - if not exist "%LIBRARY_BIN%\\glib-2.0-0.dll" exit 1  # [win]
-        - echo "STEP 2"  # [win]
         - if not exist "%LIBRARY_LIB%\\glib-2.0.lib" exit 1   # [win]
         - test ! -f ${PREFIX}/lib/libgobject-2.0.la  # [not win]
         - test ! -f ${PREFIX}/lib/libglib-2.0${SHLIB_EXT}  # [not win]
@@ -113,11 +110,8 @@ outputs:
         # Introspection data is needed at runtime
         - test -f ${PREFIX}/share/gir-1.0/GLib-2.0.gir              # [unix]
         - test -f ${PREFIX}/lib/girepository-1.0/GLib-2.0.typelib   # [unix]
-        - echo "STEP 3"  # [win]
-        - if not exist %LIBRARY_PREFIX%\share\gir-1.0\GLib-2.0.gir exit 1             # [win]
-        - echo "STEP 4"  # [win]
-        - if not exist %LIBRARY_PREFIX%\lib\girepository-1.0\GLib-2.0.typelib exit 1  # [win]
-        - echo "-------START-TEST-------"  # [win]
+        # - if not exist %LIBRARY_PREFIX%\share\gir-1.0\GLib-2.0.gir exit 1             # [win]
+        # - if not exist %LIBRARY_PREFIX%\lib\girepository-1.0\GLib-2.0.typelib exit 1  # [win]
 
   - name: glib-tools
     script: install.sh  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ build:
   number: 0
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
-  skip: True  # [py<37]
+  skip: True  # [py<37 or osx or win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,6 +76,7 @@ outputs:
       build:
         - meson >=1.4.0
         - ninja-base
+        - pkg-config  # [osx]
         - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
@@ -120,6 +121,7 @@ outputs:
       build:
         - meson >=1.4.0
         - ninja-base
+        - pkg-config  # [osx]
         - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
@@ -151,6 +153,7 @@ outputs:
       build:
         - meson >=1.4.0
         - ninja-base
+        - pkg-config  # [osx]
         - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,13 +33,14 @@ source:
     - patches/0007-disable-test_fork_fail.patch  # [linux]
 
 build:
-  number: 0
+  number: 1
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
   skip: True  # [py<37]
 
 requirements:
   build:
+    - gobject-introspection
     - meson >=1.4.0
     - cmake
     - ninja-base
@@ -74,6 +75,7 @@ outputs:
         - {{ pin_subpackage("libglib") }}
     requirements:
       build:
+        - gobject-introspection
         - meson >=1.4.0
         - ninja-base
         - {{ stdlib('c') }}
@@ -108,6 +110,11 @@ outputs:
         - test -f ${PREFIX}/lib/pkgconfig/glib-2.0.pc  # [unix]
         - test -f ${PREFIX}/etc/conda/activate.d/libglib_activate.sh  # [not win]
         - test -f ${PREFIX}/etc/conda/deactivate.d/libglib_deactivate.sh  # [not win]
+        # Introspection data is needed at runtime
+        - test -f ${PREFIX}/share/gir-1.0/GLib-2.0.gir              # [unix]
+        - test -f ${PREFIX}/lib/girepository-1.0/GLib-2.0.typelib   # [unix]
+        - if not exist %LIBRARY_PREFIX%\share\gir-1.0\GLib-2.0.gir exit 1             # [win]
+        - if not exist %LIBRARY_PREFIX%\lib\girepository-1.0\GLib-2.0.typelib exit 1  # [win]
 
   - name: glib-tools
     script: install.sh  # [unix]
@@ -115,6 +122,7 @@ outputs:
     build:
     requirements:
       build:
+        - gobject-introspection
         - meson >=1.4.0
         - ninja-base
         - {{ stdlib('c') }}
@@ -146,6 +154,7 @@ outputs:
         - {{ pin_subpackage("libglib") }}
     requirements:
       build:
+        - gobject-introspection
         - meson >=1.4.0
         - ninja-base
         - {{ stdlib('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,7 +74,6 @@ outputs:
         - {{ pin_subpackage("libglib") }}
     requirements:
       build:
-        - pkg-config
         - meson >=1.4.0
         - ninja-base
         - {{ stdlib('c') }}
@@ -119,7 +118,6 @@ outputs:
     build:
     requirements:
       build:
-        - pkg-config
         - meson >=1.4.0
         - ninja-base
         - {{ stdlib('c') }}
@@ -151,7 +149,6 @@ outputs:
         - {{ pin_subpackage("libglib") }}
     requirements:
       build:
-        - pkg-config
         - meson >=1.4.0
         - ninja-base
         - {{ stdlib('c') }}


### PR DESCRIPTION
glib 2.84.4 rebuild

**Destination channel:** {defaults}

### Links

- [{PKG-11788}](https://anaconda.atlassian.net/browse/PKG-11788) 
- Anaconda Recipes | https://github.com/AnacondaRecipes/glib-feedstock

### Explanation of changes:

- version unchanged (2.84.4 rebuild) - add gobject-introspection
- added PY314 to abs.yaml
- bld.bat/build.sh enables Meson introspection (-Dintrospection=enabled)
- meta.yaml enables Windows GIR/typelib presence checks
- linux/osx build.sh now bootstraps g-ir-scanner via conda env and sets PKG_CONFIG_PATH for introspection


