### PR TITLE
glib rebuild

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,47 +8,15 @@ mkdir %BUILD_PREFIX%\Library\etc
 echo none / cygdrive binary,user 0 0 >%BUILD_PREFIX%\Library\etc\fstab
 echo none /tmp usertemp binary,posix=0 0 0 >>%BUILD_PREFIX%\Library\etc\fstab
 
-set "GIR_PREFIX=%cd%\g-ir-prefix"
-
-REM NOTE:
-REM gobject-introspection (g-ir-scanner) is used here strictly as a *build-time tool*.
-REM On Windows, using the target Python version (e.g. 3.14) often fails to resolve
-REM a compatible dependency set (libffi / python_abi / gobject-introspection).
-REM
-REM To keep the build reliable and deterministic, we pin a known-good Python
-REM version (3.12) for the GIR build environment. The generated GIR/typelib
-REM artifacts are Python-version-independent and safe to use for all outputs.
-set "GIR_PY=3.12"
-call conda create -p %GIR_PREFIX% -c defaults -y "python=%GIR_PY%" gobject-introspection glib "setuptools"
-if errorlevel 1 exit 1
-
-REM Patch g-ir-scanner's utils.py: os.add_dll_directory() rejects relative
-REM paths on Windows (e.g. '.'), so resolve them to absolute first.
-python -c "p=r'%GIR_PREFIX%\Library\lib\gobject-introspection\giscanner\utils.py'; t=open(p).read(); t=t.replace('os.add_dll_directory(path)','os.add_dll_directory(os.path.abspath(path))'); open(p,'w').write(t)"
-
-REM Meson prepends BUILD_PREFIX python when probing extensionless scripts on
-REM Windows. Delegate to the pinned GIR bootstrap python (see build.sh on Unix).
-"%GIR_PREFIX%\python.exe" "%GIR_PREFIX%\Library\bin\g-ir-scanner" --version
-if errorlevel 1 exit 1
-
-> "%BUILD_PREFIX%\Scripts\g-ir-scanner.cmd" (
-  echo @ECHO OFF
-  echo "%GIR_PREFIX%\python.exe" "%GIR_PREFIX%\Library\bin\g-ir-scanner" %%*
-)
-
-REM gnome.generate_gir() reads g_ir_scanner from pkg-config, not PATH.
-python -c "import re,pathlib; pc=pathlib.Path(r'%GIR_PREFIX%\Library\lib\pkgconfig\gobject-introspection-1.0.pc'); w=pathlib.Path(r'%BUILD_PREFIX%\Scripts\g-ir-scanner.cmd').as_posix(); t=pc.read_text(); t=re.sub(r'^g_ir_scanner=.*$', 'g_ir_scanner='+w, t, flags=re.M); pc.write_text(t)"
-
-set "PYTHONPATH=%GIR_PREFIX%\Lib\site-packages;%PYTHONPATH%"
-set "PATH=%BUILD_PREFIX%\Scripts;%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin;%GIR_PREFIX%\Library\usr\bin;%PATH%"
+call "%RECIPE_DIR%\scripts\gir-setup.bat"
+if errorlevel 1 exit /b 1
 
 mkdir forgebuild
 cd forgebuild
 
 @REM Find libffi with pkg-config
 FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
-FOR /F "delims=" %%i IN ('cygpath.exe -m "%GIR_PREFIX%"') DO set "GIR_PREFIX_M=%%i"
-set PKG_CONFIG_PATH=%LIBRARY_PREFIX_M%/lib/pkgconfig;%LIBRARY_PREFIX_M%/share/pkgconfig;%GIR_PREFIX_M%/Library/lib/pkgconfig
+set PKG_CONFIG_PATH=%GIR_PKG_CONFIG_PATH%;%LIBRARY_PREFIX_M%/lib/pkgconfig;%LIBRARY_PREFIX_M%/share/pkgconfig
 
 @REM Avoid a Meson issue - https://github.com/mesonbuild/meson/issues/4827
 set "PYTHONLEGACYWINDOWSSTDIO=1"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -26,8 +26,18 @@ REM Patch g-ir-scanner's utils.py: os.add_dll_directory() rejects relative
 REM paths on Windows (e.g. '.'), so resolve them to absolute first.
 python -c "p=r'%GIR_PREFIX%\Library\lib\gobject-introspection\giscanner\utils.py'; t=open(p).read(); t=t.replace('os.add_dll_directory(path)','os.add_dll_directory(os.path.abspath(path))'); open(p,'w').write(t)"
 
+REM Meson prepends BUILD_PREFIX python when probing extensionless scripts on
+REM Windows. Delegate to the pinned GIR bootstrap python (see build.sh on Unix).
+"%GIR_PREFIX%\python.exe" "%GIR_PREFIX%\Library\bin\g-ir-scanner" --version
+if errorlevel 1 exit 1
+
+> "%BUILD_PREFIX%\Scripts\g-ir-scanner.cmd" (
+  echo @ECHO OFF
+  echo "%GIR_PREFIX%\python.exe" "%GIR_PREFIX%\Library\bin\g-ir-scanner" %%*
+)
+
 set "PYTHONPATH=%GIR_PREFIX%\Lib\site-packages;%PYTHONPATH%"
-set "PATH=%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin;%GIR_PREFIX%\Library\usr\bin;%PATH%"
+set "PATH=%BUILD_PREFIX%\Scripts;%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin;%GIR_PREFIX%\Library\usr\bin;%PATH%"
 
 mkdir forgebuild
 cd forgebuild

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -36,6 +36,9 @@ if errorlevel 1 exit 1
   echo "%GIR_PREFIX%\python.exe" "%GIR_PREFIX%\Library\bin\g-ir-scanner" %%*
 )
 
+REM gnome.generate_gir() reads g_ir_scanner from pkg-config, not PATH.
+python -c "import re,pathlib; pc=pathlib.Path(r'%GIR_PREFIX%\Library\lib\pkgconfig\gobject-introspection-1.0.pc'); w=pathlib.Path(r'%BUILD_PREFIX%\Scripts\g-ir-scanner.cmd').as_posix(); t=pc.read_text(); t=re.sub(r'^g_ir_scanner=.*$', 'g_ir_scanner='+w, t, flags=re.M); pc.write_text(t)"
+
 set "PYTHONPATH=%GIR_PREFIX%\Lib\site-packages;%PYTHONPATH%"
 set "PATH=%BUILD_PREFIX%\Scripts;%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin;%GIR_PREFIX%\Library\usr\bin;%PATH%"
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -22,6 +22,10 @@ set "GIR_PY=3.12"
 call conda create -p %GIR_PREFIX% -c defaults -y "python=%GIR_PY%" gobject-introspection glib "setuptools"
 if errorlevel 1 exit 1
 
+REM Patch g-ir-scanner's utils.py: os.add_dll_directory() rejects relative
+REM paths on Windows (e.g. '.'), so resolve them to absolute first.
+python -c "p=r'%GIR_PREFIX%\Library\lib\gobject-introspection\giscanner\utils.py'; t=open(p).read(); t=t.replace('os.add_dll_directory(path)','os.add_dll_directory(os.path.abspath(path))'); open(p,'w').write(t)"
+
 set "PYTHONPATH=%GIR_PREFIX%\Lib\site-packages;%PYTHONPATH%"
 set "PATH=%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin;%GIR_PREFIX%\Library\usr\bin;%PATH%"
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -19,7 +19,7 @@ REM To keep the build reliable and deterministic, we pin a known-good Python
 REM version (3.12) for the GIR build environment. The generated GIR/typelib
 REM artifacts are Python-version-independent and safe to use for all outputs.
 set "GIR_PY=3.12"
-call conda create -p %GIR_PREFIX% -y "python=%GIR_PY%" gobject-introspection glib "setuptools<71"
+call conda create -p %GIR_PREFIX% -y "python=%GIR_PY%" gobject-introspection glib "setuptools"
 if errorlevel 1 exit 1
 
 set "PYTHONPATH=%GIR_PREFIX%\Lib\site-packages;%PYTHONPATH%"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -19,7 +19,7 @@ REM To keep the build reliable and deterministic, we pin a known-good Python
 REM version (3.12) for the GIR build environment. The generated GIR/typelib
 REM artifacts are Python-version-independent and safe to use for all outputs.
 set "GIR_PY=3.12"
-call conda create -p %GIR_PREFIX% -y "python=%GIR_PY%" gobject-introspection glib "setuptools"
+call conda create -p %GIR_PREFIX% -c defaults -y "python=%GIR_PY%" gobject-introspection glib "setuptools"
 if errorlevel 1 exit 1
 
 set "PYTHONPATH=%GIR_PREFIX%\Lib\site-packages;%PYTHONPATH%"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,7 +22,7 @@ if [[ -n "${build_platform:-}" ]]; then
   export CONDA_SUBDIR="${build_platform}"
 fi
 
-conda create -p "$GIR_PREFIX" -y \
+conda create -p "$GIR_PREFIX" -c defaults -y \
   "python=${PY_VER}" \
   gobject-introspection
 

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -1,20 +1,5 @@
-set "GIR_PREFIX=%cd%\g-ir-prefix"
-
-REM _build_env is recreated before install scripts run, so recreate the GIR
-REM wrapper (see install.sh on Unix).
-> "%BUILD_PREFIX%\Scripts\g-ir-scanner.cmd" (
-  echo @ECHO OFF
-  echo "%GIR_PREFIX%\python.exe" "%GIR_PREFIX%\Library\bin\g-ir-scanner" %%*
-)
-
-python -c "import re,pathlib; pc=pathlib.Path(r'%GIR_PREFIX%\Library\lib\pkgconfig\gobject-introspection-1.0.pc'); w=pathlib.Path(r'%BUILD_PREFIX%\Scripts\g-ir-scanner.cmd').as_posix(); t=pc.read_text(); t=re.sub(r'^g_ir_scanner=.*$', 'g_ir_scanner='+w, t, flags=re.M); pc.write_text(t)"
-
-set "PYTHONPATH=%GIR_PREFIX%\Lib\site-packages;%PYTHONPATH%"
-set "PATH=%BUILD_PREFIX%\Scripts;%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin;%GIR_PREFIX%\Library\usr\bin;%PATH%"
-FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
-FOR /F "delims=" %%i IN ('cygpath.exe -m "%GIR_PREFIX%"') DO set "GIR_PREFIX_M=%%i"
-set PKG_CONFIG_PATH=%LIBRARY_PREFIX_M%/lib/pkgconfig;%LIBRARY_PREFIX_M%/share/pkgconfig;%GIR_PREFIX_M%/Library/lib/pkgconfig
-
+REM bld.bat already configured introspection; --no-rebuild avoids Meson
+REM regenerate (which would re-probe g-ir-scanner after _build_env reload).
 cd forgebuild
 meson install --no-rebuild
 if errorlevel 1 exit 1

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -1,3 +1,9 @@
+set "GIR_PREFIX=%cd%\g-ir-prefix"
+set "PATH=%BUILD_PREFIX%\Scripts;%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin;%GIR_PREFIX%\Library\usr\bin;%PATH%"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%GIR_PREFIX%"') DO set "GIR_PREFIX_M=%%i"
+set PKG_CONFIG_PATH=%LIBRARY_PREFIX_M%/lib/pkgconfig;%LIBRARY_PREFIX_M%/share/pkgconfig;%GIR_PREFIX_M%/Library/lib/pkgconfig
+
 cd forgebuild
 ninja install
 if errorlevel 1 exit 1

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -1,11 +1,22 @@
 set "GIR_PREFIX=%cd%\g-ir-prefix"
+
+REM _build_env is recreated before install scripts run, so recreate the GIR
+REM wrapper (see install.sh on Unix).
+> "%BUILD_PREFIX%\Scripts\g-ir-scanner.cmd" (
+  echo @ECHO OFF
+  echo "%GIR_PREFIX%\python.exe" "%GIR_PREFIX%\Library\bin\g-ir-scanner" %%*
+)
+
+python -c "import re,pathlib; pc=pathlib.Path(r'%GIR_PREFIX%\Library\lib\pkgconfig\gobject-introspection-1.0.pc'); w=pathlib.Path(r'%BUILD_PREFIX%\Scripts\g-ir-scanner.cmd').as_posix(); t=pc.read_text(); t=re.sub(r'^g_ir_scanner=.*$', 'g_ir_scanner='+w, t, flags=re.M); pc.write_text(t)"
+
+set "PYTHONPATH=%GIR_PREFIX%\Lib\site-packages;%PYTHONPATH%"
 set "PATH=%BUILD_PREFIX%\Scripts;%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin;%GIR_PREFIX%\Library\usr\bin;%PATH%"
 FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -m "%GIR_PREFIX%"') DO set "GIR_PREFIX_M=%%i"
 set PKG_CONFIG_PATH=%LIBRARY_PREFIX_M%/lib/pkgconfig;%LIBRARY_PREFIX_M%/share/pkgconfig;%GIR_PREFIX_M%/Library/lib/pkgconfig
 
 cd forgebuild
-ninja install
+meson install --no-rebuild
 if errorlevel 1 exit 1
 
 if NOT [%PKG_NAME%] == [glib] (

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -9,7 +9,7 @@ export PATH="${BUILD_PREFIX}/bin:${PATH}"
 export GIR_PREFIX="${SRC_DIR}/g-ir-prefix"
 
 if [[ ! -x "${GIR_PREFIX}/bin/g-ir-scanner" ]]; then
-  conda create -p "${GIR_PREFIX}" -y \
+  conda create -p "${GIR_PREFIX}" -c defaults -y \
     "python=${PY_VER}" gobject-introspection
 fi
 

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -2,45 +2,10 @@
 
 set -ex
 
-# Put it first, so any subprocesses also see it
-export PATH="${BUILD_PREFIX}/bin:${PATH}"
-
-# Bootstrap gobject-introspection tools (without touching meta.yaml)
-export GIR_PREFIX="${SRC_DIR}/g-ir-prefix"
-
-if [[ ! -x "${GIR_PREFIX}/bin/g-ir-scanner" ]]; then
-  conda create -p "${GIR_PREFIX}" -c defaults -y \
-    "python=${PY_VER}" gobject-introspection
-fi
-
-# Make g-ir-scanner available in PATH (Meson looking it there)
-mkdir -p "${BUILD_PREFIX}/bin"
-cat > "${BUILD_PREFIX}/bin/g-ir-scanner" <<'EOF'
-#!/usr/bin/env bash
-exec "${GIR_PREFIX}/bin/g-ir-scanner" "$@"
-EOF
-chmod +x "${BUILD_PREFIX}/bin/g-ir-scanner"
-
-export PATH="${BUILD_PREFIX}/bin:${PATH}"
-
-# For Meson to help find gobject-introspection-1.0.pc
-export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig:${PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH:-}"
-if [[ -d "${GIR_PREFIX}/lib/pkgconfig" ]]; then
-  export PKG_CONFIG_PATH="${GIR_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
-fi
-
-# DEBUG
-# echo "PKG_CONFIG=$PKG_CONFIG"
-# $PKG_CONFIG --version
-# $PKG_CONFIG --modversion gobject-introspection-1.0 || true
-# $PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0 || true
-# which g-ir-scanner
-# g-ir-scanner --version
-
-unset _CONDA_PYTHON_SYSCONFIGDATA_NAME
-
+# build.sh already configured introspection; --no-rebuild avoids Meson
+# regenerate during split-package install.
 cd builddir
-ninja install || (cat meson-logs/meson-log.txt; false)
+meson install --no-rebuild || (cat meson-logs/meson-log.txt; false)
 # remove libtool files
 find $PREFIX -name '*.la' -delete
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     - patches/0006-Skip-flaky-tests-on-linux-CI.patch  # [linux]
 
 build:
-  number: 0
+  number: 1
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
   skip: True  # [py<37]
@@ -54,7 +54,7 @@ requirements:
     - gettext {{ gettext }}  # [osx]
     - zlib {{ zlib }}
     - pcre2 {{ pcre2 }}
-    - libiconv 1.16
+    - libiconv {{ libiconv }}
   run:
     - python
     # run-dep as a workaround for now; upstream package still imports from distutils

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,7 @@ outputs:
         - gettext {{ gettext }}  # [osx]
         - zlib {{ zlib }}
         - pcre2 {{ pcre2 }}
-        - libiconv
+        - libiconv {{ libiconv }}
       run:
         - gettext >=0.21.0,<1.0a0  # [osx]
         # bounds through run_exports

--- a/recipe/scripts/gir-setup.bat
+++ b/recipe/scripts/gir-setup.bat
@@ -1,0 +1,32 @@
+@REM Bootstrap gobject-introspection for Windows GIR generation.
+@REM
+@REM Meson on Windows runs host python + extensionless g-ir-scanner, but GI is
+@REM built for a pinned bootstrap python. We install a cmd wrapper, copy/patch
+@REM gobject-introspection-1.0.pc under BUILD_PREFIX, and prepend that to
+@REM PKG_CONFIG_PATH (see build.sh / install.sh on Unix).
+@REM
+@REM Sets: PATH, PYTHONPATH, GIR_PKG_CONFIG_PATH
+
+set "GIR_PREFIX=%cd%\g-ir-prefix"
+set "GIR_PY=3.12"
+
+call conda create -p "%GIR_PREFIX%" -c defaults -y "python=%GIR_PY%" gobject-introspection glib "setuptools"
+if errorlevel 1 exit /b 1
+
+> "%BUILD_PREFIX%\Scripts\g-ir-scanner.cmd" (
+  echo @ECHO OFF
+  echo "%GIR_PREFIX%\python.exe" "%GIR_PREFIX%\Library\bin\g-ir-scanner" %%*
+)
+
+python "%RECIPE_DIR%\scripts\gir-setup.py" "%GIR_PREFIX%" "%BUILD_PREFIX%"
+if errorlevel 1 exit /b 1
+
+set "PYTHONPATH=%GIR_PREFIX%\Lib\site-packages;%PYTHONPATH%"
+set "PATH=%BUILD_PREFIX%\Scripts;%GIR_PREFIX%\Library;%GIR_PREFIX%\Library\bin;%GIR_PREFIX%\Library\usr\bin;%PATH%"
+
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%GIR_PREFIX%"') DO set "GIR_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%BUILD_PREFIX%"') DO set "BUILD_PREFIX_M=%%i"
+set "GIR_PKG_CONFIG_PATH=%BUILD_PREFIX_M%/Library/lib/pkgconfig;%GIR_PREFIX_M%/Library/lib/pkgconfig"
+
+"%BUILD_PREFIX%\Scripts\g-ir-scanner.cmd" --version
+if errorlevel 1 exit /b 1

--- a/recipe/scripts/gir-setup.py
+++ b/recipe/scripts/gir-setup.py
@@ -24,12 +24,12 @@ def patch_scanner_utils(gir_prefix: pathlib.Path) -> None:
         gir_prefix
         / "Library/lib/gobject-introspection/giscanner/utils.py"
     )
-    text = utils_py.read_text()
-    text = text.replace(
-        "os.add_dll_directory(path)",
-        "os.add_dll_directory(os.path.abspath(path))",
-    )
-    utils_py.write_text(text)
+    text = utils_py.read_text(encoding="utf-8")
+    old = "os.add_dll_directory(path)"
+    new = "os.add_dll_directory(os.path.abspath(path))"
+    if old not in text:
+        raise RuntimeError(f"Expected patch target not found in {utils_py}")
+    utils_py.write_text(text.replace(old, new), encoding="utf-8")
 
 
 def install_pc_override(gir_prefix: pathlib.Path, build_prefix: pathlib.Path) -> None:

--- a/recipe/scripts/gir-setup.py
+++ b/recipe/scripts/gir-setup.py
@@ -1,0 +1,71 @@
+"""Windows gobject-introspection bootstrap helpers for glib-feedstock.
+
+Invoked by ``gir-setup.bat`` during the Windows build (see ``bld.bat``).
+Meson on Windows invokes ``g-ir-scanner`` with the host Python, but the
+bootstrap GI environment is pinned to a separate prefix (``g-ir-prefix``).
+This script applies the file mutations that ``gir-setup.bat`` cannot express
+readably in batch: patching GI's DLL search helper and installing a patched
+``gobject-introspection-1.0.pc`` under ``BUILD_PREFIX`` so the original
+under ``GIR_PREFIX`` is left untouched.
+"""
+import argparse
+import pathlib
+import re
+import shutil
+
+
+def patch_scanner_utils(gir_prefix: pathlib.Path) -> None:
+    """Fix ``g-ir-scanner`` DLL path handling on Windows.
+
+    ``os.add_dll_directory()`` rejects relative paths (e.g. ``'.'``), which
+    causes import failures when Meson runs the scanner.
+    """
+    utils_py = (
+        gir_prefix
+        / "Library/lib/gobject-introspection/giscanner/utils.py"
+    )
+    text = utils_py.read_text()
+    text = text.replace(
+        "os.add_dll_directory(path)",
+        "os.add_dll_directory(os.path.abspath(path))",
+    )
+    utils_py.write_text(text)
+
+
+def install_pc_override(gir_prefix: pathlib.Path, build_prefix: pathlib.Path) -> None:
+    """Install a patched ``gobject-introspection-1.0.pc`` under ``build_prefix``.
+
+    Copies the ``.pc`` file from the GI bootstrap env and rewrites
+    ``g_ir_scanner=`` to point at ``build_prefix/Scripts/g-ir-scanner.cmd``.
+    ``gnome.generate_gir()`` reads this variable from pkg-config rather than
+    ``PATH``, so Meson must see the wrapper path here (with forward slashes).
+    """
+    src = gir_prefix / "Library/lib/pkgconfig/gobject-introspection-1.0.pc"
+    dst_dir = build_prefix / "Library/lib/pkgconfig"
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    dst = dst_dir / "gobject-introspection-1.0.pc"
+    shutil.copy2(src, dst)
+
+    wrapper = (build_prefix / "Scripts/g-ir-scanner.cmd").as_posix()
+    text = dst.read_text()
+    text = re.sub(
+        r"^g_ir_scanner=.*$",
+        f"g_ir_scanner={wrapper}",
+        text,
+        flags=re.M,
+    )
+    dst.write_text(text)
+
+
+def main() -> None:
+    """Patch GI utils and install the pkg-config override for ``g_ir_scanner``."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("gir_prefix", type=pathlib.Path)
+    parser.add_argument("build_prefix", type=pathlib.Path)
+    args = parser.parse_args()
+    patch_scanner_utils(args.gir_prefix)
+    install_pc_override(args.gir_prefix, args.build_prefix)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
glib rebuild— Windows GIR bootstrap + install fixes

**Destination channel:** defaults

### Links
- [PKG-15405](https://anaconda.atlassian.net/browse/PKG-15405)

### Summary
Prepares glib for **Windows ARM64** by fixing GObject Introspection (GIR) generation and split-package install on Windows. No version bump — build number **1** for the recipe changes.

### Changes
- **Refactor Windows GIR bootstrap** into `recipe/scripts/gir-setup.bat` + `gir-setup.py`:
  - Pin a bootstrap env (`python 3.12` + `gobject-introspection`) with `-c defaults`
  - Add `g-ir-scanner.cmd` wrapper so Meson uses the bootstrap Python
  - Patch `giscanner/utils.py` (`os.add_dll_directory` needs absolute paths)
  - Install a patched `gobject-introspection-1.0.pc` under `BUILD_PREFIX` so `g_ir_scanner` points at the wrapper
- **Install phase:** use `meson install --no-rebuild` on Windows and Unix so split outputs don’t re-run Meson configure after the build env changes
- **Unix:** drop duplicated GIR bootstrap from `install.sh` (handled in `build.sh`); bootstrap `conda create` uses `-c defaults`
- **meta.yaml:** pin `libiconv` via CBC (`{{ libiconv }}`); relax hardcoded `setuptools<71` in the GI bootstrap env

### Why
Meson on Windows invokes `g-ir-scanner` with the host Python, but GI is built in a separate bootstrap prefix. Without the wrapper and pkg-config override, GIR generation fails — blocking reliable Windows builds and **win-arm64** once that subdir is in the aggregate matrix.


[PKG-15405]: https://anaconda.atlassian.net/browse/PKG-15405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ