### PR TITLE
Test for glib-2.0.pc on windows.

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,7 @@
 # 4 hours timeout for Windows build (default is 2 hours)
-task_timeout: 14400# the conda-build parameters to use for disabling --skip-existing
+task_timeout: 14400
+
+# the conda-build parameters to use for disabling --skip-existing
 build_parameters:
   - "--suppress-variables"
+  - "--skip-existing"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
-# the conda-build parameters to use for disabling --skip-existing
-build_parameters:
-  - "--suppress-variables"
-
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
+# 4 hours timeout for Windows build (default is 2 hours)
+task_timeout: 14400

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,4 @@
 # 4 hours timeout for Windows build (default is 2 hours)
-task_timeout: 14400
+task_timeout: 14400# the conda-build parameters to use for disabling --skip-existing
+build_parameters:
+  - "--suppress-variables"

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -41,16 +41,6 @@ if NOT [%PKG_NAME%] == [glib] (
 
   rmdir /s /q %LIBRARY_PREFIX%\lib\glib-2.0\include
   if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\lib\pkgconfig\gio-*
-  if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\lib\pkgconfig\glib-*
-  if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\lib\pkgconfig\gmodule-*
-  if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\lib\pkgconfig\gobject-*
-  if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\lib\pkgconfig\gthread-*
-  if errorlevel 1 exit 1
 
   del %LIBRARY_PREFIX%\share\aclocal\glib-*
   if errorlevel 1 exit 1
@@ -60,6 +50,13 @@ if NOT [%PKG_NAME%] == [glib] (
   if errorlevel 1 exit 1
   rmdir /s /q %LIBRARY_PREFIX%\share\glib-2.0
   if errorlevel 1 exit 1
+)
+
+@REM intl.lib is statically linked on Windows; do not advertise -lintl in .pc files.
+if exist %LIBRARY_PREFIX%\lib\pkgconfig\*.pc (
+  for %%f in (%LIBRARY_PREFIX%\lib\pkgconfig\*.pc) do (
+    sed -i "s/-lintl//g" %%f
+  )
 )
 
 rem We don't have bash as a dependency so these shouldn't exist, but

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -53,10 +53,7 @@ if NOT [%PKG_NAME%] == [glib] (
 )
 
 @REM intl.lib is statically linked on Windows; do not advertise -lintl in .pc files.
-@REM For libglib/glib-tools, also drop .pc variables that reference pruned dev files.
-set "FIX_PC_ARGS="
-if NOT [%PKG_NAME%] == [glib] set "FIX_PC_ARGS=--trim-runtime"
-python %RECIPE_DIR%\scripts\fix-pkgconfig.py %LIBRARY_PREFIX% %FIX_PC_ARGS%
+python %RECIPE_DIR%\scripts\fix-pkgconfig.py %LIBRARY_PREFIX%
 if errorlevel 1 exit 1
 
 rem We don't have bash as a dependency so these shouldn't exist, but

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -53,11 +53,11 @@ if NOT [%PKG_NAME%] == [glib] (
 )
 
 @REM intl.lib is statically linked on Windows; do not advertise -lintl in .pc files.
-if exist %LIBRARY_PREFIX%\lib\pkgconfig\*.pc (
-  for %%f in (%LIBRARY_PREFIX%\lib\pkgconfig\*.pc) do (
-    sed -i "s/-lintl//g" %%f
-  )
-)
+@REM For libglib/glib-tools, also drop .pc variables that reference pruned dev files.
+set "FIX_PC_ARGS="
+if NOT [%PKG_NAME%] == [glib] set "FIX_PC_ARGS=--trim-runtime"
+python %RECIPE_DIR%\scripts\fix-pkgconfig.py %LIBRARY_PREFIX% %FIX_PC_ARGS%
+if errorlevel 1 exit 1
 
 rem We don't have bash as a dependency so these shouldn't exist, but
 rem sometimes a system bash will be picked up and they will get installed.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     - patches/0006-Skip-flaky-tests-on-linux-CI.patch  # [linux]
 
 build:
-  number: 1
+  number: 2
   # Keep in sync with
   # https://gitlab.gnome.org/GNOME/glib/-/blob/2.84.2/meson.build?ref_type=tags#L2503
   skip: True  # [py<37]
@@ -101,6 +101,7 @@ outputs:
         - test ! -f ${PREFIX}/lib/libgobject-2.0.la  # [not win]
         - test ! -f ${PREFIX}/lib/libglib-2.0${SHLIB_EXT}  # [not win]
         - test -f ${PREFIX}/lib/pkgconfig/glib-2.0.pc  # [unix]
+        - if not exist "%LIBRARY_LIB%\\pkgconfig\\glib-2.0.pc" exit 1  # [win]
         - test -f ${PREFIX}/etc/conda/activate.d/libglib_activate.sh  # [not win]
         - test -f ${PREFIX}/etc/conda/deactivate.d/libglib_deactivate.sh  # [not win]
         # Introspection test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,8 +103,6 @@ outputs:
         - test -f ${PREFIX}/lib/pkgconfig/glib-2.0.pc  # [unix]
         - if not exist "%LIBRARY_LIB%\\pkgconfig\\glib-2.0.pc" exit 1  # [win]
         - findstr /C:"-lintl" "%LIBRARY_LIB%\\pkgconfig\\*.pc" >nul && exit /B 1 || exit /B 0  # [win]
-        - findstr /C:"includedir}/glib-2.0" "%LIBRARY_LIB%\\pkgconfig\\glib-2.0.pc" >nul && exit /B 1 || exit /B 0  # [win]
-        - if exist "%LIBRARY_LIB%\\pkgconfig\\gio-windows-2.0.pc" exit /B 1  # [win]
         - test -f ${PREFIX}/etc/conda/activate.d/libglib_activate.sh  # [not win]
         - test -f ${PREFIX}/etc/conda/deactivate.d/libglib_deactivate.sh  # [not win]
         # Introspection test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -102,6 +102,9 @@ outputs:
         - test ! -f ${PREFIX}/lib/libglib-2.0${SHLIB_EXT}  # [not win]
         - test -f ${PREFIX}/lib/pkgconfig/glib-2.0.pc  # [unix]
         - if not exist "%LIBRARY_LIB%\\pkgconfig\\glib-2.0.pc" exit 1  # [win]
+        - findstr /C:"-lintl" "%LIBRARY_LIB%\\pkgconfig\\*.pc" >nul && exit /B 1 || exit /B 0  # [win]
+        - findstr /C:"includedir}/glib-2.0" "%LIBRARY_LIB%\\pkgconfig\\glib-2.0.pc" >nul && exit /B 1 || exit /B 0  # [win]
+        - if exist "%LIBRARY_LIB%\\pkgconfig\\gio-windows-2.0.pc" exit /B 1  # [win]
         - test -f ${PREFIX}/etc/conda/activate.d/libglib_activate.sh  # [not win]
         - test -f ${PREFIX}/etc/conda/deactivate.d/libglib_deactivate.sh  # [not win]
         # Introspection test

--- a/recipe/scripts/fix-pkgconfig.py
+++ b/recipe/scripts/fix-pkgconfig.py
@@ -1,0 +1,139 @@
+"""Post-process pkg-config files after meson install on Windows.
+
+Called from ``install.bat`` once per split-package output.  Meson emits
+``.pc`` files for the full development tree; the ``libglib`` and
+``glib-tools`` outputs then prune headers, tools, and schema data.  This
+script keeps the surviving ``.pc`` files consistent with what each output
+actually ships.
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+# Variable lines that reference binaries or data removed from runtime outputs.
+_RUNTIME_VAR_PREFIXES: dict[str, tuple[str, ...]] = {
+    "glib-2.0.pc": (
+        "glib_genmarshal=",
+        "gobject_query=",
+        "glib_mkenums=",
+        "glib_valgrind_suppressions=",
+    ),
+    "gio-2.0.pc": (
+        "schemasdir=",
+        "dtdsdir=",
+        "giomoduledir=",
+        "gio=",
+        "gio_querymodules=",
+        "glib_compile_schemas=",
+        "glib_compile_resources=",
+        "gdbus=",
+        "gdbus_codegen=",
+        "gresource=",
+        "gsettings=",
+    ),
+}
+
+# ``Cflags`` lines that point at headers pruned from runtime outputs.
+_RUNTIME_CFLAGS_PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
+    "glib-2.0.pc": (
+        re.compile(r"^Cflags:.*glib-2\.0"),
+    ),
+    "gio-2.0.pc": (
+        re.compile(r"^Cflags:"),
+    ),
+}
+
+_RUNTIME_REMOVE_FILES = frozenset({"gio-windows-2.0.pc"})
+
+
+def _normalize_libs_line(line: str) -> str:
+    key, sep, value = line.partition(":")
+    if not sep or key not in ("Libs", "Libs.private"):
+        return line
+    value = " ".join(value.split())
+    newline = "\n"
+    if line.endswith("\r\n"):
+        newline = "\r\n"
+    elif not line.endswith("\n"):
+        newline = ""
+    return f"{key}: {value}{newline}"
+
+
+def strip_lintl(text: str) -> str:
+    """Remove ``-lintl`` from every ``Libs`` / ``Libs.private`` line."""
+    out: list[str] = []
+    for line in text.splitlines(keepends=True):
+        if line.startswith(("Libs:", "Libs.private:")):
+            line = line.replace("-lintl", "")
+            line = _normalize_libs_line(line)
+        out.append(line)
+    return "".join(out)
+
+
+def trim_runtime_pc(text: str, filename: str) -> str | None:
+    """Drop stale variables and ``Cflags`` from a runtime-output ``.pc`` file.
+
+    Returns ``None`` when the file should be deleted entirely.
+    """
+    if filename in _RUNTIME_REMOVE_FILES:
+        return None
+
+    drop_prefixes = _RUNTIME_VAR_PREFIXES.get(filename, ())
+    drop_cflags = _RUNTIME_CFLAGS_PATTERNS.get(filename, ())
+
+    out: list[str] = []
+    for line in text.splitlines(keepends=True):
+        stripped = line.lstrip()
+        if any(stripped.startswith(prefix) for prefix in drop_prefixes):
+            continue
+        if any(pattern.match(stripped) for pattern in drop_cflags):
+            continue
+        out.append(line)
+    return "".join(out)
+
+
+def process_pc_dir(
+    pc_dir: pathlib.Path,
+    *,
+    trim_runtime: bool,
+) -> None:
+    if not pc_dir.is_dir():
+        return
+
+    for pc_path in sorted(pc_dir.glob("*.pc")):
+        text = pc_path.read_text(encoding="utf-8")
+        text = strip_lintl(text)
+        if trim_runtime:
+            trimmed = trim_runtime_pc(text, pc_path.name)
+            if trimmed is None:
+                pc_path.unlink()
+                continue
+            text = trimmed
+        pc_path.write_text(text, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "library_prefix",
+        type=pathlib.Path,
+        help="Windows LIBRARY_PREFIX (e.g. $PREFIX/Library)",
+    )
+    parser.add_argument(
+        "--trim-runtime",
+        action="store_true",
+        help="Prune dev-only .pc content for libglib/glib-tools outputs",
+    )
+    args = parser.parse_args(argv)
+
+    pc_dir = args.library_prefix / "lib" / "pkgconfig"
+    process_pc_dir(pc_dir, trim_runtime=args.trim_runtime)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/recipe/scripts/fix-pkgconfig.py
+++ b/recipe/scripts/fix-pkgconfig.py
@@ -1,53 +1,15 @@
 """Post-process pkg-config files after meson install on Windows.
 
-Called from ``install.bat`` once per split-package output.  Meson emits
-``.pc`` files for the full development tree; the ``libglib`` and
-``glib-tools`` outputs then prune headers, tools, and schema data.  This
-script keeps the surviving ``.pc`` files consistent with what each output
-actually ships.
+Called from ``install.bat`` for every split-package output.  Meson emits
+``-lintl`` in ``Libs`` / ``Libs.private`` lines because libintl is linked
+on Windows, but intl is statically linked into GLib and must not be
+advertised to downstream consumers.
 """
 from __future__ import annotations
 
 import argparse
 import pathlib
-import re
 import sys
-
-
-# Variable lines that reference binaries or data removed from runtime outputs.
-_RUNTIME_VAR_PREFIXES: dict[str, tuple[str, ...]] = {
-    "glib-2.0.pc": (
-        "glib_genmarshal=",
-        "gobject_query=",
-        "glib_mkenums=",
-        "glib_valgrind_suppressions=",
-    ),
-    "gio-2.0.pc": (
-        "schemasdir=",
-        "dtdsdir=",
-        "giomoduledir=",
-        "gio=",
-        "gio_querymodules=",
-        "glib_compile_schemas=",
-        "glib_compile_resources=",
-        "gdbus=",
-        "gdbus_codegen=",
-        "gresource=",
-        "gsettings=",
-    ),
-}
-
-# ``Cflags`` lines that point at headers pruned from runtime outputs.
-_RUNTIME_CFLAGS_PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
-    "glib-2.0.pc": (
-        re.compile(r"^Cflags:.*glib-2\.0"),
-    ),
-    "gio-2.0.pc": (
-        re.compile(r"^Cflags:"),
-    ),
-}
-
-_RUNTIME_REMOVE_FILES = frozenset({"gio-windows-2.0.pc"})
 
 
 def _normalize_libs_line(line: str) -> str:
@@ -74,45 +36,12 @@ def strip_lintl(text: str) -> str:
     return "".join(out)
 
 
-def trim_runtime_pc(text: str, filename: str) -> str | None:
-    """Drop stale variables and ``Cflags`` from a runtime-output ``.pc`` file.
-
-    Returns ``None`` when the file should be deleted entirely.
-    """
-    if filename in _RUNTIME_REMOVE_FILES:
-        return None
-
-    drop_prefixes = _RUNTIME_VAR_PREFIXES.get(filename, ())
-    drop_cflags = _RUNTIME_CFLAGS_PATTERNS.get(filename, ())
-
-    out: list[str] = []
-    for line in text.splitlines(keepends=True):
-        stripped = line.lstrip()
-        if any(stripped.startswith(prefix) for prefix in drop_prefixes):
-            continue
-        if any(pattern.match(stripped) for pattern in drop_cflags):
-            continue
-        out.append(line)
-    return "".join(out)
-
-
-def process_pc_dir(
-    pc_dir: pathlib.Path,
-    *,
-    trim_runtime: bool,
-) -> None:
+def process_pc_dir(pc_dir: pathlib.Path) -> None:
     if not pc_dir.is_dir():
         return
 
     for pc_path in sorted(pc_dir.glob("*.pc")):
-        text = pc_path.read_text(encoding="utf-8")
-        text = strip_lintl(text)
-        if trim_runtime:
-            trimmed = trim_runtime_pc(text, pc_path.name)
-            if trimmed is None:
-                pc_path.unlink()
-                continue
-            text = trimmed
+        text = strip_lintl(pc_path.read_text(encoding="utf-8"))
         pc_path.write_text(text, encoding="utf-8")
 
 
@@ -123,15 +52,10 @@ def main(argv: list[str] | None = None) -> int:
         type=pathlib.Path,
         help="Windows LIBRARY_PREFIX (e.g. $PREFIX/Library)",
     )
-    parser.add_argument(
-        "--trim-runtime",
-        action="store_true",
-        help="Prune dev-only .pc content for libglib/glib-tools outputs",
-    )
     args = parser.parse_args(argv)
 
     pc_dir = args.library_prefix / "lib" / "pkgconfig"
-    process_pc_dir(pc_dir, trim_runtime=args.trim_runtime)
+    process_pc_dir(pc_dir)
     return 0
 
 


### PR DESCRIPTION
### Summary
Fixes missing pkg-config files in the Windows `libglib` output. The split install script was deleting all `*.pc` files for every non-`glib` output, including `libglib`. Unix already tested for `glib-2.0.pc`; Windows did not, so the regression went unnoticed.
This rebuild (build number 2, glib 2.86.3 unchanged):
- Stops deleting pkg-config files from `libglib` (and `glib-tools`) during the Windows split install
- Post-processes installed `.pc` files to remove `-lintl` from `Libs` / `Libs.private` lines — `intl.lib` is statically linked into GLib on Windows and must not be advertised to downstream consumers (see patch `0004-Manually-link-with-libiconv-whenever-we-use-libintl..patch`)
- Adds Windows regression tests for `libglib`:
  - `glib-2.0.pc` exists under `%LIBRARY_LIB%\pkgconfig\`
  - no `.pc` file contains `-lintl`
Also updates `abs.yaml`:
- Set `task_timeout: 14400` (4 h) for Windows builds that exceed the default 2 h limit
- Remove deprecated `ANACONDA_ROCKET_ENABLE_PY314` (py3.14 is in aggregate CBC)
- Add `--skip-existing` to `build_parameters`
### Motivation
Downstream Windows packages that depend on `libglib` and use `pkg-config` (e.g. Meson/CMake builds) need `glib-2.0.pc` in the `libglib` package. On Unix this file is shipped and tested; on Windows it was removed during `install.bat` split pruning.
Anaconda’s three-way split (`libglib` / `glib-tools` / `glib`) differs from conda-forge, which keeps `.pc` files only in the umbrella `glib` output. For Anaconda, `libglib` is the development/runtime library output and should mirror Unix behavior.

### Notes
- This remove's the need for this hack https://github.com/AnacondaRecipes/cairo-feedstock/commit/34c1ebf31b25e24263e1d9caf53af4a0f44f5950#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aR54 and fixes https://github.com/AnacondaRecipes/gobject-introspection-feedstock/pull/20/changes
- The GH UI isn't updating, the win-64 task completed successfully. 